### PR TITLE
Add package documentation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -94,6 +94,7 @@
 ## Developers
 
 * [Plugins](developers/plugins.md)
+* [Packages](developers/packages.md)
 * [Backend API](developers/backend-api/README.md)
   * [Lookup Tables](developers/backend-api/lookup-tables.md)
   * [Extensions](developers/backend-api/extensions.md)

--- a/developers/packages.md
+++ b/developers/packages.md
@@ -2,12 +2,290 @@
 
 A package is a plugin that defines a list of features (such as dashboards, datasources etc.) that can be installed by an Live admin user. It also defines a list of required identified channels and plugins. Its file structure is shown below.:
 
-- live-plugins/plugin-my-package
-  - pom.xml
-    - src/main/resource
-        - manifest.yaml
+* live-plugins/plugin-my-package
+  * pom.xml
+    * src/main/resource
+        * manifest.yaml
 
-All packages require the plugin-package-manager. Without it, Live will not recognize a package plugin as a package and will not allow the admin user to install the features.
+All packages require the [plugin-package-manager](https://marketplace.intelie.com/artifact/plugin-package-manager). Without it, Live will not recognize a package plugin as a package and will not allow the admin user to install the features.
 
 ## The package manager plugin
 The package manager plugin requires Live 3.29.0 or newer, and adds a new section to the admin screen. In this section, all installed packages are listed:
+
+![image](https://user-images.githubusercontent.com/17753656/211353399-95f939bf-9751-4fb7-924a-ac9ef03fd6b9.png)
+
+Accessing a package, we can visualize its details, as well as activate and deactivate its features. There is also the possibility to inactivate the entire package, providing a way to hide all installed features at once, without losing its configuration.
+
+![image](https://user-images.githubusercontent.com/17753656/211353467-c98a89a5-2578-48ea-a016-23f7c5fc3e57.png)
+
+Every feature installed by a package can't be edited.
+
+Packaging also allows the package creator to define a feature README (using markdown) and its version. It's also possible to register the changelog, but it isn't displayed at the user interface yet.
+
+## Supported features
+The package manager allows to create packages containing the following features:
+
+Dashboards
+Datasources
+Groovy Snippets *
+Lookup Tables
+Pipes Modules
+Rules
+JS snippets *
+CSS snippets *
+
+{% hint style="info" %}
+IMPORTANT: If a package contains a JS or a CSS snippets it must require the [web snippets plugin](https://marketplace.intelie.com/artifact/plugin-websnippets). If it contains a Groovy Snippet, it should require the [plugin-groovy](https://marketplace.intelie.com/artifact/plugin-groovy/). See more about dependecies at required plugins section.
+{% endhint %}  
+
+## Dependecies
+
+### Required plugins
+All packages require plugin package manager. Without it, Live will not recognize a package plugin as a package and will not allow the admin user to install the features.
+
+As already mentioned, if a package contains a JS or a CSS snippet, it should require the [plugin-websnippets](https://marketplace.intelie.com/artifact/plugin-websnippets). If it contains a Groovy snippet, it should require the [plugin-groovy](https://marketplace.intelie.com/artifact/plugin-groovy/).
+
+These dependencies should be described at the manifest.yaml file. The following example shows a package that depends on plugin-package-manager, plugin-websnippets and plugin-feed.
+
+```
+name: ${project.artifactId}
+version: ${revision}
+build: ${CI_PIPELINE_ID}
+expectedLiveVersion: ${live-api-version}
+requirePlugins:
+  - plugin-package-manager
+  - plugin-websnippets
+  - plugin-feed
+```
+
+### Identified channels
+Packages may require certain channel identifications to be configured in Live. This dependencies should also be described at the manifest.yaml, using the requiredEntities. For example:
+
+```
+name: ${project.artifactId}
+version: ${revision}
+build: ${CI_PIPELINE_ID}
+expectedLiveVersion: ${live-api-version}
+requirePlugins:
+  - plugin-package-manager
+  - plugin-websnippets
+  - plugin-feed
+
+actions:
+
+  - op: packageFeatures
+    package:
+      title: Package Title
+      uuid: 16335801-f46c-42db-a6d3-295f4f096ae4
+
+      requiredEntities:
+        - { type: "IDENTIFIED_CHANNEL", key: "standpipe_pressure" }
+        - { type: "IDENTIFIED_CHANNEL", key: "rotary_speed" }
+        - { type: "IDENTIFIED_CHANNEL", key: "torque" }
+```
+
+## Adding features
+
+All features can be defined by the manifest.yaml file. A example is shown bellow:
+
+{% hint style="info" %}
+IMPORTANT: The version 4 UUID must be generate a must not be reused. 
+{% endhint %}  
+
+```
+name: ${project.artifactId}
+version: ${revision}
+build: ${CI_PIPELINE_ID}
+expectedLiveVersion: ${live-api-version}
+requirePlugins:
+  - plugin-package-manager
+  - plugin-websnippets
+  - plugin-groovy
+
+actions:
+
+  - op: packageFeatures
+    package:
+      title: Hello World
+      uuid: dc4aed81-2e6c-4519-b18c-6143ec394431
+      #icon: icon_48x48.png
+
+      datasources:
+        datasource_example:
+          uuid: 42861930-a2e9-46ed-9d61-5ba02000dd81
+          version: "1.0"
+          content:
+            title: "Packaging Example"
+            identifier: "packaging_example"
+            description: "Packaging example"
+            text: "Rule text"
+            expression:
+              include: datasources/package_example.pipes
+
+      rules:
+        package_example:
+          uuid: d9774736-17f0-4463-b375-a8c6b7c1d195
+          version: "1.0"
+          content:
+            name: "Packaging Example"
+            description: "Example rule"
+            text: "Rule text"
+            severity: INFO
+            expression:
+              include: rules/package_example.pipes
+
+
+      dashboards:
+        packaging_example:
+          uuid: 629574b3-7327-4008-9fa0-3b0a3f06f941
+          content:
+            title: "Packaging Example"
+            include: dashboards/packaging_example.json
+          version: "2.0"
+          readme: |
+            A long remark regarding the member. Markdown syntax may be used for rich text
+            representation and all. **Bold** and *italics* are supported.
+            [Links](https://google.com/) go well, too. Remember that soft breaks are only
+            made with two spaces at the end of the line so you can break lines normally on
+            the manifest if needed.
+            
+            
+            Separate paragraphs with a blank line between them.
+
+            # Heading level 1
+
+            1. list item
+            2. list item
+                1. nested list
+                2. nested list
+            3. list item
+
+            ## Heading level 2
+
+            - list item
+            - list item
+                - nested list
+                - nested list
+            - list item
+
+            ### Heading level 3
+
+            1. list item
+                - mixed list
+
+            #### Heading level 4
+
+            - list item
+                1. mixed list
+
+            ##### Heading level 5
+
+            > This is a blockquote.
+            >
+            > It can span multiple paragraphs like this.
+
+            ###### Heading level 6
+
+            ```
+            This is a code block.
+            ```
+
+            C'est fini!
+          changelog:
+            2.0: |
+              # Fixes and improvements
+              - Added new widget Y
+              - Improving widget X
+            1.1: |
+              # Fixes
+              - Improving widget W
+
+
+      pipes_modules:
+        packaging_example:
+          uuid: a60edaa0-e035-47ef-a5d2-8f765e6f002f
+          version: "1.0"
+          label: "Packaging example"
+          content:
+            expression:
+              include: pipes-modules/packaging_example.pipes
+          changelog:
+            1.0: |
+              # New features
+              - Export common channels' aliases
+
+      groovy_snippets:
+        packaging_example:
+          uuid: d858677c-7062-4bb5-95e6-20f0521ca085
+          version: "1.0"
+          label: "Packaging example"
+          content:
+            code:
+              include: groovy-snippets/packaging_example.groovy
+
+      js_snippets:
+        packaging_example:
+          uuid: b9208357-2e7b-42cf-898a-6d6264a391a7
+          version: "1.0"
+          content:
+            position: HEAD_BEGIN
+            code:
+              include: js-snippets/packaging_example.js
+
+      css_snippets:
+        packaging_example:
+          uuid: 8a73c60b-72e1-4dcf-bd4f-2bc279e56b85
+          version: "1.0"
+          content:
+            position: HEAD_END
+            code:
+              include: css-snippets/packaging_example.css
+
+      lookup_tables:
+        packaging_example:
+          uuid: 8244d8b8-89f8-48c2-a404-a46887824f1f
+          version: "1.0"
+          content:
+            name: "Packaging Example"
+            entries:
+              - {key: "x", value: "1"}
+              - {key: "hello", value: "world"}
+
+        packaging_second_example:
+          uuid: c700c38a-d67e-41dd-80fc-a5e5fabf5a07
+          version: "1.0"
+          content:
+            qualifier: "packaging_second_example"
+            name: "Packaging Second Example"
+            entries:
+              include: lookup-tables/packaging_second_example.json
+
+
+      requiredEntities:
+        - { type: "IDENTIFIED_CHANNEL", key: "standpipe_pressure" }
+        - { type: "IDENTIFIED_CHANNEL", key: "rotary_speed" }
+        - { type: "IDENTIFIED_CHANNEL", key: "torque" }
+```
+
+The `include` indicates the location of the feature content. So, for this example, the file structure will be: 
+
+* live-plugins/plugin-my-package
+  * pom.xml
+    * src/main/resource
+      * css-snippets/
+        * packaging_example.css
+      * dashboards/
+        * packaging_example.json
+      * datasources/
+        * packaging_example.pipes
+      * groovy-snippets/
+        * packaging_example.groovy
+      * js-snippets/
+        * packaging_example.js
+      * lookup-tables/
+        * packaging_example.json 
+      * pipes-modules/
+        * packaging_example.pipes
+      * rules/
+        * package_example.pipes 
+      * manifest.yaml

--- a/developers/packages.md
+++ b/developers/packages.md
@@ -1,6 +1,6 @@
 # Packages
 
-A package is a plugin that defines a list of features (such as dashboards, datasources etc.) that can be installed by an Live admin user. It also defines a list of required identified channels and plugins. Its file structure is shown below.:
+A package is a plugin that defines a list of features (such as dashboards, datasources etc.) that can be installed by an Live admin user. It also defines a list of required identified channels and plugins. These definitions should be stored inside a manifest file, that can be either yaml or json. An example for a package source structure is shown below:
 
 * live-plugins/plugin-my-package
   * pom.xml
@@ -8,6 +8,8 @@ A package is a plugin that defines a list of features (such as dashboards, datas
         * manifest.yaml
 
 All packages require the [plugin-package-manager](https://marketplace.intelie.com/artifact/plugin-package-manager). Without it, Live will not recognize a package plugin as a package and will not allow the admin user to install the features.
+
+At the moment that a package is installed, the features are not installed automatically. Some of them may require manual configuration. For example, before installing a dashboard, we need to define its perspective.
 
 ## The package manager plugin
 The package manager plugin requires Live 3.29.0 or newer, and adds a new section to the admin screen. In this section, all installed packages are listed:
@@ -18,7 +20,7 @@ Accessing a package, we can visualize its details, as well as activate and deact
 
 ![image](https://user-images.githubusercontent.com/17753656/211353467-c98a89a5-2578-48ea-a016-23f7c5fc3e57.png)
 
-Every feature installed by a package can't be edited.
+Package manager plugin is not responsible for restricting access to installed objects, at the moment, installed entities will be responsible for permission semantics. At the moment, Live core entities, as well as JS, CSS and Groovy snippets, cannot be edited when created by a plugin
 
 Packaging also allows the package creator to define a feature README (using markdown) and its version. It's also possible to register the changelog, but it isn't displayed at the user interface yet.
 
@@ -38,6 +40,8 @@ CSS snippets *
 IMPORTANT: If a package contains a JS or a CSS snippets it must require the [web snippets plugin](https://marketplace.intelie.com/artifact/plugin-websnippets). If it contains a Groovy Snippet, it should require the [plugin-groovy](https://marketplace.intelie.com/artifact/plugin-groovy/). See more about dependecies at required plugins section.
 {% endhint %}  
 
+Package manager exposes the `EntitiyRegistryService` service, that allows other plugins to register new entities types `registerEntityType(@NotNull Live live, @NotNull EntityMapper mapper)` .
+
 ## Dependecies
 
 ### Required plugins
@@ -45,7 +49,7 @@ All packages require plugin package manager. Without it, Live will not recognize
 
 As already mentioned, if a package contains a JS or a CSS snippet, it should require the [plugin-websnippets](https://marketplace.intelie.com/artifact/plugin-websnippets). If it contains a Groovy snippet, it should require the [plugin-groovy](https://marketplace.intelie.com/artifact/plugin-groovy/).
 
-These dependencies should be described at the manifest.yaml file. The following example shows a package that depends on plugin-package-manager, plugin-websnippets and plugin-feed.
+These dependencies should be described at the manifest file. The following example shows a package that depends on plugin-package-manager, plugin-websnippets and plugin-feed.
 
 ```
 name: ${project.artifactId}
@@ -59,7 +63,7 @@ requirePlugins:
 ```
 
 ### Identified channels
-Packages may require certain channel identifications to be configured in Live. This dependencies should also be described at the manifest.yaml, using the requiredEntities. For example:
+Packages may require certain channel identifications to be configured in Live. This dependencies should also be described at the manifest, using the requiredEntities. For example:
 
 ```
 name: ${project.artifactId}
@@ -86,7 +90,7 @@ actions:
 
 ## Adding features
 
-All features can be defined by the manifest.yaml file. A example is shown bellow:
+All features can be defined by the manifest file. A example is shown bellow:
 
 {% hint style="info" %}
 IMPORTANT: The version 4 UUID must be generate a must not be reused. 

--- a/developers/packages.md
+++ b/developers/packages.md
@@ -1,0 +1,13 @@
+# Packages
+
+A package is a plugin that defines a list of features (such as dashboards, datasources etc.) that can be installed by an Live admin user. It also defines a list of required identified channels and plugins. Its file structure is shown below.:
+
+- live-plugins/plugin-my-package
+  - pom.xml
+    - src/main/resource
+        - manifest.yaml
+
+All packages require the plugin-package-manager. Without it, Live will not recognize a package plugin as a package and will not allow the admin user to install the features.
+
+## The package manager plugin
+The package manager plugin requires Live 3.29.0 or newer, and adds a new section to the admin screen. In this section, all installed packages are listed:

--- a/developers/packages.md
+++ b/developers/packages.md
@@ -20,7 +20,7 @@ Accessing a package, we can visualize its details, as well as activate and deact
 
 ![image](https://user-images.githubusercontent.com/17753656/211353467-c98a89a5-2578-48ea-a016-23f7c5fc3e57.png)
 
-Package manager plugin is not responsible for restricting access to installed objects, at the moment, installed entities will be responsible for permission semantics. At the moment, Live core entities, as well as JS, CSS and Groovy snippets, cannot be edited when created by a plugin
+Package manager plugin is not responsible for restricting access to installed objects, at the moment, installed entities will be responsible for permission semantics. At the moment, Live core features, as well as JS, CSS and Groovy snippets, cannot be edited when created by a plugin.
 
 Packaging also allows the package creator to define a feature README (using markdown) and its version. It's also possible to register the changelog, but it isn't displayed at the user interface yet.
 
@@ -40,7 +40,8 @@ CSS snippets *
 IMPORTANT: If a package contains a JS or a CSS snippets it must require the [web snippets plugin](https://marketplace.intelie.com/artifact/plugin-websnippets). If it contains a Groovy Snippet, it should require the [plugin-groovy](https://marketplace.intelie.com/artifact/plugin-groovy/). See more about dependecies at required plugins section.
 {% endhint %}  
 
-Package manager exposes the `EntitiyRegistryService` service, that allows other plugins to register new entities types `registerEntityType(@NotNull Live live, @NotNull EntityMapper mapper)` .
+## Extending plugin-package-manager to add more features
+It's also possible to add more features using the exposed `EntitiyRegistryService`. It allows other plugins to add new entities types using `registerEntityType(@NotNull Live live, @NotNull EntityMapper mapper)`.
 
 ## Dependecies
 

--- a/developers/packages.md
+++ b/developers/packages.md
@@ -41,7 +41,7 @@ IMPORTANT: If a package contains a JS or a CSS snippets it must require the [web
 {% endhint %}  
 
 ## Extending plugin-package-manager to add more features
-It's also possible to add more features using the exposed `EntitiyRegistryService`. It allows other plugins to add new entities types using `registerEntityType(@NotNull Live live, @NotNull EntityMapper mapper)`.
+Package manager plugin exposes the `EntitiyRegistryService` service, that allows other plugins to register new entities types and, therefore, more features.
 
 ## Dependecies
 

--- a/developers/plugins.md
+++ b/developers/plugins.md
@@ -1,12 +1,12 @@
 # Plugins
 
-Plugins are packages of code that provide one or more different features. Plugins can change Live behavior in many different ways, from creating a new visualization or integration to providing a completely new real time engine.
+Plugins can change Live behavior in many different ways, from creating a new visualization or integration to providing a completely new real time engine.
 
 A plugin can be either:
 
-* a JAR package
-* a ZIP package
-* a ZIP package with a `manifest.json`
+* a JAR
+* a ZIP
+* a ZIP with a `manifest.json`
 * a Groovy script
 * a JDBC driver
 
@@ -14,23 +14,23 @@ A plugin can be either:
 Most of the major features of Intelie Live, such as integrations with databases, web interface, and so on, are provided through plugins.
 {% endhint %}
 
-### JAR packages
+### JAR plugins
 
 A Java plugin can contain Java and Javascript code, as well as code in any language that runs in the JVM, such as Groovy or Scala.
 
-A Java plugin should depend on the [live-api](https://search.maven.org/search?q=live-api) library. See [Backend API](backend-api/) section for further information how to create a Java Live plugin. Plugins assembled as JAR packages are also labeled FULL plugins.
+A Java plugin should depend on the [live-api](https://search.maven.org/search?q=live-api) library. See [Backend API](backend-api/) section for further information how to create a Java Live plugin. Plugins assembled as JAR plugins are also labeled FULL plugins.
 
-### Zip packages
+### Zip plugins
 
 A ZIP package can be used to provide static web content.
 
 In that case, a ZIP may contain a folder called `webcontent`. The files in this folder will be provided at the URL`/content/plugin-name.zip/`. It's a useful approach to upload customer assets as fonts, icons, background images or JSON data files.
 
-Plugins assembled as zip packages are also labeled CONTENT\_NO\_MANIFEST plugins.
+Plugins assembled as zip plugins are also labeled CONTENT\_NO\_MANIFEST plugins.
 
-### Zip packages with a manifest.json
+### Zip plugins with a manifest.json
 
-Additionally to ordinary zip packages a plugin can contain both `webcontent`folder as `manifest.json` to indicate to Live a set of manifest actions to perform. Plugins assembled as zip packages including a manifes.json are also labeled CONTENT plugins.
+Additionally to ordinary zip plugins a plugin can contain both `webcontent`folder as `manifest.json` to indicate to Live a set of manifest actions to perform. Plugins assembled as zip plugins including a manifes.json are also labeled CONTENT plugins.
 
 Some examples of manifest actions supported in Live that promotes extensibility :
 
@@ -40,9 +40,9 @@ Some examples of manifest actions supported in Live that promotes extensibility 
   * **cssSnippet** : (optional) JSON object containing `code`property with the stringified CSS content
   * **jsFile** : (optional) JSON object containing `path` property to the javacript file location relative to plugin location (example: `/content/plugin-name.zip/bundle.js`)
   * **jsSnippet** : (optional) JSON object containing `code`property with the stringified JS content
-* **AddContent** : allows the dynamic load of some content inside the zip package to the Live URL path. Arguments:
+* **AddContent** : allows the dynamic load of some content inside the zip plugin to the Live URL path. Arguments:
   * **path** : string relative to Live plugin URL path that will be created
-  * **location** : string relative to the contents of zip package where the file should be loaded from
+  * **location** : string relative to the contents of zip plugin where the file should be loaded from
 
 See how these actions help the plugin development in [WebSetup](backend-api/web-setup.md) and [Live Widget Packaging](web-application/dashboard-and-widgets/live-widget-packaging.md) sections.
 

--- a/developers/web-application/dashboard-and-widgets/live-widget-packaging.md
+++ b/developers/web-application/dashboard-and-widgets/live-widget-packaging.md
@@ -1,6 +1,6 @@
 # Live Widget Packaging
 
-### JAR Packages
+### JAR
 
 Since Live Widget is mainly a frontend application the creation of a full Java plugin is not necessary but could be convenient when developing Widget Query Handlers and additional features as Web Services as well. As discussed in [WebSetup](../../backend-api/web-setup.md) section of [Backend API](../../backend-api/), the Java Main class needs only the following:
 
@@ -16,7 +16,7 @@ public class Main implements LivePlugin {
 }
 ```
 
-### ZIP Packages with manifest.json
+### ZIP with manifest.json
 
 The developer could create a ZIP containing a `manifest.json` and ships its`target/bundle.js` (typically compiled to ES6 using [BabelJS](https://babeljs.io) or other transpiler) on the zip file as described in [Plugins](../../plugins.md).
 


### PR DESCRIPTION
- Add documentation about packages
- Remove the "package" word from `developers/plugins.md` and `developers/web-application/dashboard-and-widgets/live-widget-packaging.md`  to avoid ambiguity 