### PR TITLE
Add another appendix with extension information for back-end developers

### DIFF
--- a/developers/backend-api/extensions.md
+++ b/developers/backend-api/extensions.md
@@ -323,4 +323,6 @@ entityContext.find(new AllExtensions()); // list all extensions configured (acti
 
 The `EntityContext` API and Live Data API will be discussed in details in another section.
 
+{% hint style="info" %} Frontend plugins have no such API to list extensions (or generic entities). Each resource in Live REST API is protected according. For example, the `/rest/extension` endpoint list all extensions but it is restricted to Live administrative users only.  {% endhint %}
+
 {% endcode %}

--- a/developers/backend-api/extensions.md
+++ b/developers/backend-api/extensions.md
@@ -309,4 +309,36 @@ throws Exception {
 }
 // ...
 ```
+
+## Appendix: Finding all extensions created
+
+In case you want to find all extensions created by the users of your plugin or any other, you may find in `getContext()` in live API. Remember: this data is also available in `https://foo.intelie.com/rest/extension`
+
+```java
+//...
+public final class AllLiveExtensions {
+    private final EntityList extensions;
+    @NotNull
+    private final Live live;
+
+    public final EntityList getExtensions() {
+        return this.extensions;
+    }
+
+    @NotNull
+    public final Live getLive() {
+        return this.live;
+    }
+
+    public AllLiveExtensions(@NotNull Live live) {
+        this.live = live;
+        this.extensions = live.data().getContext().find((Specification)(new AllExtensions()));
+        
+    }
+}
+//...
+```
+
+ Since `context` belongs to another section we are not getting into its details.
+
 {% endcode %}

--- a/developers/backend-api/extensions.md
+++ b/developers/backend-api/extensions.md
@@ -316,26 +316,8 @@ In case you want to find all extensions created by the users of your plugin or a
 
 ```java
 //...
-public final class AllLiveExtensions {
-    private final EntityList extensions;
-    @NotNull
-    private final Live live;
-
-    public final EntityList getExtensions() {
-        return this.extensions;
-    }
-
-    @NotNull
-    public final Live getLive() {
-        return this.live;
-    }
-
-    public AllLiveExtensions(@NotNull Live live) {
-        this.live = live;
-        this.extensions = live.data().getContext().find((Specification)(new AllExtensions()));
-        
-    }
-}
+EntityContext entityContext = live.data().getContext(); // Live API EntityContext wraps the access to Live model persistence
+entityContext.find(new AllExtensions()); // list all extensions configured (active or inactive) in the Live runtime
 //...
 ```
 

--- a/developers/backend-api/extensions.md
+++ b/developers/backend-api/extensions.md
@@ -312,7 +312,7 @@ throws Exception {
 
 ## Appendix: Finding all extensions created
 
-In case you want to find all extensions created by the users of your plugin or any other, you may find in `getContext()` in live API. Remember: this data is also available in `https://foo.intelie.com/rest/extension`
+In case you need to list all extensions created, you may use the `live.data().getContext()` API and the `AllExtensions` Live facility as the criteria to query the underlay SQL database. The Live package `net.intelie.live.queries` delivers other similar facilities for all Live basic entities (e.g dashboards, datasources, plugins, perspectives, etc).
 
 ```java
 //...
@@ -321,6 +321,6 @@ entityContext.find(new AllExtensions()); // list all extensions configured (acti
 //...
 ```
 
- Since `context` belongs to another section we are not getting into its details.
+The `EntityContext` API and Live Data API will be discussed in details in another section.
 
 {% endcode %}


### PR DESCRIPTION
Added another appendix with information that was hard for me to find in the documentation.
The example given is a simple way to access the extensions created in Live to use in the back end.

Even though it does not belong here it is really necessary to mention all places that touch the subject.
Notes: 
- This does not belong to extensions, but it is really helpful to mention.
- Also mention using the service endpoint to get the same data.