### PR TITLE
Fix 3.47.0 release notes

### DIFF
--- a/release-notes/live-3/3.47.0.md
+++ b/release-notes/live-3/3.47.0.md
@@ -7,6 +7,7 @@ description: Released September 7, 2024
 ### New features
 
 * Feature Flag to BLOCK automatic Index Creation from specific dashboards
+* Create Storage Provider Indexes Metrics
 
 ### Improvements
 

--- a/release-notes/live-3/3.47.0.md
+++ b/release-notes/live-3/3.47.0.md
@@ -6,25 +6,10 @@ description: Released September 7, 2024
 
 ### New features
 
-* Multiple Persistent Queues
 * Feature Flag to BLOCK automatic Index Creation from specific dashboards
-* Create a new endpoint to list plugins that have `SessionFactory` registered
-* Add Tag/Comment Feature to Entity Versioning API
-* Allow plugin entities to be edited by the system admin through UI
-* Index registration may verify if the index is already created before to proceed to create them
-* Allow users to create thinner charts (half the current width)
-* Move plugin-math to separate project
-* Write a Javadoc for Live API's - (Index)
-* Allow registering Plugin repositories
-* Add the Graph to the Storage Stats Overview
-* New feature for message reactions using emojis
 
 ### Improvements
 
 * Add the possibility of making widgets hidden by default in dashboard edit mode
 * Allow interpolation of nonexistent points on line charts
-
-### Bugfixes
-
-* QA | Storage Stats layout issues
 


### PR DESCRIPTION
Fix the 3.47.0 release notes removing the wrong references of open issues.